### PR TITLE
Limit PWM value to 255 before passing to analogWrite

### DIFF
--- a/Ejemplos/Seguidor_de_linea_blanca/TB6612FNG.ino
+++ b/Ejemplos/Seguidor_de_linea_blanca/TB6612FNG.ino
@@ -37,7 +37,7 @@ void MotorIz(int value) {
   }
 
   // Setea Velocidad
-  if (value > 255){
+  if (value > 255) {
     value = 255;
   } 
 
@@ -60,7 +60,7 @@ void MotorDe(int value) {
   }
 
   // Setea Velocidad
-  if (value > 255){
+  if (value > 255) {
     value = 255;
   } 
 

--- a/Ejemplos/Seguidor_de_linea_blanca/TB6612FNG.ino
+++ b/Ejemplos/Seguidor_de_linea_blanca/TB6612FNG.ino
@@ -37,6 +37,9 @@ void MotorIz(int value) {
   }
 
   // Setea Velocidad
+  if (value > 255){
+    value = 255;
+  } 
 
   analogWrite(PWMA, value);
 }
@@ -57,6 +60,9 @@ void MotorDe(int value) {
   }
 
   // Setea Velocidad
+  if (value > 255){
+    value = 255;
+  } 
 
   analogWrite(PWMB, value);
 }


### PR DESCRIPTION
In order to prevent errors from users of this code, I think it is safer to set a limit to the PWM value before calling analogWrite